### PR TITLE
Post link with text

### DIFF
--- a/Example/ExampleTests/XNGNetworkFeedTests.m
+++ b/Example/ExampleTests/XNGNetworkFeedTests.m
@@ -190,6 +190,34 @@
      }];
 }
 
+- (void)testPostLinkWithComment {
+    [self.testHelper executeCall:
+     ^{
+         [[XNGAPIClient sharedClient] postLink:@"blalup"
+                                          text:@"plomPlom"
+                                       success:nil
+                                       failure:nil];
+     }
+                withExpectations:
+     ^(NSURLRequest *request, NSMutableDictionary *query, NSMutableDictionary *body) {
+         expect(request.URL.host).to.equal(@"api.xing.com");
+         expect(request.URL.path).to.equal(@"/v1/users/me/share/link");
+         expect(request.HTTPMethod).to.equal(@"POST");
+         
+         [self.testHelper removeOAuthParametersInQueryDict:query];
+         
+         expect([query allKeys]).to.haveCountOf(0);
+         
+         expect([body valueForKey:@"uri"]).to.equal(@"blalup");
+         [body removeObjectForKey:@"uri"];
+         
+         expect([body valueForKey:@"text"]).to.equal(@"plomPlom");
+         [body removeObjectForKey:@"text"];
+         
+         expect([body allKeys]).to.haveCountOf(0);
+     }];
+}
+
 - (void)testGetSingleActivity {
     [self.testHelper executeCall:
      ^{

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,27 +1,27 @@
 PODS:
-  - AFNetworking (2.5.0):
-    - AFNetworking/NSURLConnection (= 2.5.0)
-    - AFNetworking/NSURLSession (= 2.5.0)
-    - AFNetworking/Reachability (= 2.5.0)
-    - AFNetworking/Security (= 2.5.0)
-    - AFNetworking/Serialization (= 2.5.0)
-    - AFNetworking/UIKit (= 2.5.0)
-  - AFNetworking/NSURLConnection (2.5.0):
+  - AFNetworking (2.5.1):
+    - AFNetworking/NSURLConnection (= 2.5.1)
+    - AFNetworking/NSURLSession (= 2.5.1)
+    - AFNetworking/Reachability (= 2.5.1)
+    - AFNetworking/Security (= 2.5.1)
+    - AFNetworking/Serialization (= 2.5.1)
+    - AFNetworking/UIKit (= 2.5.1)
+  - AFNetworking/NSURLConnection (2.5.1):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.5.0):
+  - AFNetworking/NSURLSession (2.5.1):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.5.0)
-  - AFNetworking/Security (2.5.0)
-  - AFNetworking/Serialization (2.5.0)
-  - AFNetworking/UIKit (2.5.0):
+  - AFNetworking/Reachability (2.5.1)
+  - AFNetworking/Security (2.5.1)
+  - AFNetworking/Serialization (2.5.1)
+  - AFNetworking/UIKit (2.5.1):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-  - Expecta (0.3.1)
-  - OCMock (3.1.1)
+  - Expecta (0.3.2)
+  - OCMock (3.1.2)
   - OHHTTPStubs (3.1.0)
   - SSKeychain (1.2.2)
   - XNGAPIClient (1.1.1):
@@ -43,9 +43,9 @@ EXTERNAL SOURCES:
     :path: ../XNGAPIClient.podspec
 
 SPEC CHECKSUMS:
-  AFNetworking: 0f54cb5d16ce38c1b76948faffb8d5fb705021c7
-  Expecta: 03aabd0a89d8dea843baecb19a7fd7466a69a31d
-  OCMock: f6cb8c162ab9d5620dddf411282c7b2c0ee78854
+  AFNetworking: 8bee59492a6ff15d69130efa4d0dc67e0094a52a
+  Expecta: ee641011fe10aa1855d487b40e4976dac50ec342
+  OCMock: ecdd510b73ef397f2f97274785c1e87fd147c49f
   OHHTTPStubs: 8b032ab399e356050010ed34613ee1761c6c8ae3
   SSKeychain: cc48bd3ad24fcd9125adb9e0d23dd50b8bbd08b9
   XNGAPIClient: 0d37237f4f44a4539e8279f843d1fdc48fe19674

--- a/XNGAPIClient/XNGAPIClient+NetworkFeed.h
+++ b/XNGAPIClient/XNGAPIClient+NetworkFeed.h
@@ -75,6 +75,16 @@
          failure:(void (^)(NSError *error))failure;
 
 /**
+ Create a new activity containing the link and text(optional)....
+ 
+ https://dev.xing.com/docs/post/users/me/share/link
+ */
+- (void)postLink:(NSString *)uri
+            text:(NSString *)text
+         success:(void (^)(id JSON))success
+         failure:(void (^)(NSError *error))failure;
+
+/**
  Returns a single activity. The response format is the same as the one in the network or user feed, even though a single activity will never be aggregated....
 
  https://dev.xing.com/docs/get/activities/:id

--- a/XNGAPIClient/XNGAPIClient+NetworkFeed.m
+++ b/XNGAPIClient/XNGAPIClient+NetworkFeed.m
@@ -95,12 +95,21 @@
     [self.operationQueue addOperation:operation];
 }
 
-- (void)postLink:(NSString*)uri
+- (void)postLink:(NSString *)uri
+         success:(void (^)(id JSON))success
+         failure:(void (^)(NSError *error))failure {
+    [self postLink:uri text:nil success:success failure:failure];
+}
+
+- (void)postLink:(NSString *)uri
+            text:(NSString *)text
          success:(void (^)(id JSON))success
          failure:(void (^)(NSError *error))failure {
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
     parameters[@"uri"] = uri;
-
+    if ([text length] > 0) {
+        parameters[@"text"] = text;
+    }
     NSString *path = @"v1/users/me/share/link";
     [self postJSONPath:path parameters:parameters success:success failure:failure];
 }


### PR DESCRIPTION
Add new method to allow posting links with text (possible as an optional parameter if we look at https://dev.xing.com/docs/post/users/me/share/link )