### PR TITLE
Use CircleCI instead of Travis

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -1,4 +1,5 @@
 coverage_service: coveralls
+ci_service: circleci
 xcodeproj: Example/Example.xcodeproj
 source_directory: XNGAPIClient
 ignore:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: objective-c
-osx_image: xcode61
-env: OS=8.1
-install:
-  - bundle install 
-  - bundle exec pod install --project-directory=Example
-script: bundle exec rake spec
-after_success: bundle exec slather

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you have any questions please open an issue.
 
 ===
 
-[![Build Status](http://img.shields.io/travis/xing/XNGAPIClient.svg?style=flat)](https://travis-ci.org/xing/XNGAPIClient)
+[![Build Status](https://img.shields.io/circleci/project/xing/XNGAPIClient/master.svg?style=flat)](https://circleci.com/gh/xing/XNGAPIClient)
 [![Coverage Status](http://img.shields.io/coveralls/xing/XNGAPIClient/master.svg?style=flat)](https://coveralls.io/r/xing/XNGAPIClient)
 [![Dependency Status](https://www.versioneye.com/objective-c/xngapiclient/badge.svg?style=flat)](https://www.versioneye.com/objective-c/xngapiclient)
 [![Reference Status](https://www.versioneye.com/objective-c/xngapiclient/reference_badge.svg?style=flat)](https://www.versioneye.com/objective-c/xngapiclient/references)

--- a/circle.yml
+++ b/circle.yml
@@ -10,4 +10,5 @@ dependencies:
 test:
   override:
     - bundle exec rake spec
+  post:
     - bundle exec slather

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,13 @@
+machine:
+  environment:
+    OS: 8.3
+  xcode:
+    version: "6.3.1"
+dependencies:
+  pre:
+    - bundle install 
+    - bundle exec pod install --project-directory=Example
+test:
+  override:
+    - bundle exec rake spec
+    - bundle exec slather


### PR DESCRIPTION
Travis seems to be unreliable when it comes to iOS projects so I switched to CircleCI. Right now it is blazing fast and there is no wait time (3s) in comparison to Travis (10m). Builds are faster too 3m50s compared to 5m39s