### PR TITLE
Adds new parameter to load shared contacts for visitor of my profile

### DIFF
--- a/Example/ExampleTests/XNGProfileVisitsTests.m
+++ b/Example/ExampleTests/XNGProfileVisitsTests.m
@@ -28,6 +28,7 @@
          [[XNGAPIClient sharedClient] getVisitsWithLimit:0
                                                   offset:0
                                                    since:nil
+                                  numberOfSharedContacts:0
                                                stripHTML:NO
                                                  success:nil
                                                  failure:nil];
@@ -52,6 +53,7 @@
          [[XNGAPIClient sharedClient] getVisitsWithLimit:20
                                                   offset:40
                                                    since:@"some_date"
+                                  numberOfSharedContacts:10
                                                stripHTML:YES
                                                  success:nil
                                                  failure:nil];
@@ -71,6 +73,8 @@
          [query removeObjectForKey:@"strip_html"];
          expect([query valueForKey:@"since"]).to.equal(@"some_date");
          [query removeObjectForKey:@"since"];
+         expect([query valueForKey:@"shared_contacts"]).to.equal(@"10");
+         [query removeObjectForKey:@"shared_contacts"];
 
          expect([query allKeys]).to.haveCountOf(0);
 

--- a/XNGAPIClient/XNGAPIClient+ProfileVisits.h
+++ b/XNGAPIClient/XNGAPIClient+ProfileVisits.h
@@ -36,6 +36,13 @@
                    success:(void (^)(id JSON))success
                    failure:(void (^)(NSError *error))failure;
 
+- (void)getVisitsWithLimit:(NSInteger)limit
+                    offset:(NSInteger)offset
+                     since:(NSString *)since
+                 stripHTML:(BOOL)stripHTML
+                   success:(void (^)(id JSON))success
+                   failure:(void (^)(NSError *error))failure DEPRECATED_MSG_ATTRIBUTE("Please use getVisitsWithLimit:offset:numberOfSharedContacts:stripHTML:success:failure instead");;
+
 /**
  Cancel all get visits operation that are currently running/queued.
  */

--- a/XNGAPIClient/XNGAPIClient+ProfileVisits.h
+++ b/XNGAPIClient/XNGAPIClient+ProfileVisits.h
@@ -31,6 +31,7 @@
 - (void)getVisitsWithLimit:(NSInteger)limit
                     offset:(NSInteger)offset
                      since:(NSString *)since
+    numberOfSharedContacts:(NSUInteger)numberOfSharedContacts  // Default is 0, maximum are 10 shared contacts
                  stripHTML:(BOOL)stripHTML
                    success:(void (^)(id JSON))success
                    failure:(void (^)(NSError *error))failure;

--- a/XNGAPIClient/XNGAPIClient+ProfileVisits.m
+++ b/XNGAPIClient/XNGAPIClient+ProfileVisits.m
@@ -27,11 +27,12 @@
 #pragma mark - public methods
 
 - (void)getVisitsWithLimit:(NSInteger)limit
-                       offset:(NSInteger)offset
-                        since:(NSString *)since
-                    stripHTML:(BOOL)stripHTML
-                      success:(void (^)(id JSON))success
-                      failure:(void (^)(NSError *error))failure {
+                    offset:(NSInteger)offset
+                     since:(NSString *)since
+    numberOfSharedContacts:(NSUInteger)numberOfSharedContacts
+                 stripHTML:(BOOL)stripHTML
+                   success:(void (^)(id JSON))success
+                   failure:(void (^)(NSError *error))failure {
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
     if (limit) {
         parameters[@"limit"] = @(limit);
@@ -44,6 +45,11 @@
     }
     if (stripHTML) {
         parameters[@"strip_html"] = @"true";
+    }
+    
+    if (numberOfSharedContacts > 0) {
+        numberOfSharedContacts = MIN(numberOfSharedContacts, 10);
+        parameters[@"shared_contacts"] = @(numberOfSharedContacts);
     }
 
     NSString *path = [self visitsPath];

--- a/XNGAPIClient/XNGAPIClient+ProfileVisits.m
+++ b/XNGAPIClient/XNGAPIClient+ProfileVisits.m
@@ -26,6 +26,22 @@
 
 #pragma mark - public methods
 
+// DEPRECATED
+- (void)getVisitsWithLimit:(NSInteger)limit
+                    offset:(NSInteger)offset
+                     since:(NSString *)since
+                 stripHTML:(BOOL)stripHTML
+                   success:(void (^)(id JSON))success
+                   failure:(void (^)(NSError *error))failure {
+    [self getVisitsWithLimit:limit
+                      offset:offset
+                       since:since
+      numberOfSharedContacts:0
+                   stripHTML:stripHTML
+                     success:success
+                     failure:failure];
+}
+
 - (void)getVisitsWithLimit:(NSInteger)limit
                     offset:(NSInteger)offset
                      since:(NSString *)since


### PR DESCRIPTION
This optional parameter allows us to load the shared contacts for each visitor of my profiles.

Default is 0
Max value of shared contacts is : 10

Also added deprecated method and marked it