### PR TITLE
Add PUT for setting a company as primary company

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# CHANGELOG
+
+## Next Version
+
+* Add PUT for setting a company as primary company [#72](https://github.com/xing/XNGAPIClient/pull/72)
+

--- a/Example/ExampleTests/XNGProfileEditingTests.m
+++ b/Example/ExampleTests/XNGProfileEditingTests.m
@@ -246,9 +246,9 @@
 
 - (void)testUpdatePrimarySchool {
     [self.testHelper executeCall:^{
-        [[XNGAPIClient sharedClient] putUpdatePrimarySchoolID:@"123"
-                                                      success:nil
-                                                      failure:nil];
+        [[XNGAPIClient sharedClient] putUpdatePrimarySchoolWithID:@"123"
+                                                          success:nil
+                                                          failure:nil];
     } withExpectations:^(NSURLRequest *request, NSMutableDictionary *query, NSMutableDictionary *body) {
         expect(request.URL.host).to.equal(@"api.xing.com");
         expect(request.URL.path).to.equal(@"/v1/users/me/educational_background/primary_school");

--- a/Example/ExampleTests/XNGProfileEditingTests.m
+++ b/Example/ExampleTests/XNGProfileEditingTests.m
@@ -393,6 +393,23 @@
     }];
 }
 
+- (void)testUpdatePrimaryCompany {
+    [self.testHelper executeCall:^{
+        [[XNGAPIClient sharedClient] putUpdatePrimaryCompanyWithID:@"123"
+                                                           success:nil
+                                                           failure:nil];
+    } withExpectations:^(NSURLRequest *request, NSMutableDictionary *query, NSMutableDictionary *body) {
+        expect(request.URL.host).to.equal(@"api.xing.com");
+        expect(request.URL.path).to.equal(@"/v1/users/me/professional_experience/primary_company");
+        expect(request.HTTPMethod).to.equal(@"PUT");
+
+        expect([query allKeys]).to.haveCountOf(0);
+        expect([body valueForKey:@"company_id"]).to.equal(@"123");
+        [body removeObjectForKey:@"company_id"];
+        expect([body allKeys]).to.haveCountOf(0);
+    }];
+}
+
 - (void)testUpdateLanguage {
     [self.testHelper executeCall:^{
         [[XNGAPIClient sharedClient] putUpdateLanguageWithIdentifier:@"de"

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.h
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.h
@@ -128,9 +128,9 @@ https://dev.xing.com/docs/put/users/me/private_address
 
  https://dev.xing.com/docs/put/users/me/educational_background/primary_school
 */
-- (void)putUpdatePrimarySchoolID:(NSString *)schoolID
-                         success:(void (^)(id JSON))success
-                         failure:(void (^)(NSError *error))failure;
+- (void)putUpdatePrimarySchoolWithID:(NSString *)schoolID
+                             success:(void (^)(id JSON))success
+                             failure:(void (^)(NSError *error))failure;
 
 /**
  Add a qualification to the users educational background

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.h
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.h
@@ -194,6 +194,15 @@ https://dev.xing.com/docs/put/users/me/private_address
                     failure:(void (^)(NSError *error))failure;
 
 /**
+ Update a company to be the primary company
+
+ https://dev.xing.com/docs/put/users/me/professional_experience/primary_company
+ */
+- (void)putUpdatePrimaryCompanyWithID:(NSString *)companyID
+                              success:(void (^)(id JSON))success
+                              failure:(void (^)(NSError *error))failure;
+
+/**
  Updates the given language skill from the profile
 
  https://dev.xing.com/docs/put/users/me/languages/:language

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.m
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.m
@@ -389,6 +389,18 @@
     [self deleteJSONPath:path parameters:nil success:success failure:failure];
 }
 
+- (void)putUpdatePrimaryCompanyWithID:(NSString *)companyID
+                              success:(void (^)(id JSON))success
+                              failure:(void (^)(NSError *error))failure {
+    if (!companyID) {
+        return;
+    }
+
+    NSDictionary *parameters = @{@"company_id": companyID};
+    NSString *path = @"/v1/users/me/professional_experience/primary_company";
+    [self putJSONPath:path JSONParameters:parameters success:success failure:failure];
+}
+
 - (void)putUpdateLanguageWithIdentifier:(NSString *)language
                                   skill:(NSString *)skill
                                 success:(void (^)(id JSON))success

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.m
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.m
@@ -241,9 +241,9 @@
     [self deleteJSONPath:path parameters:nil success:success failure:failure];
 }
 
-- (void)putUpdatePrimarySchoolID:(NSString *)schoolID
-                         success:(void (^)(id JSON))success
-                         failure:(void (^)(NSError *error))failure {
+- (void)putUpdatePrimarySchoolWithID:(NSString *)schoolID
+                             success:(void (^)(id JSON))success
+                             failure:(void (^)(NSError *error))failure {
     if (!schoolID) {
         return;
     }


### PR DESCRIPTION
This PR adds a call we have overlooked so far in implementing.

It also fixes a typo in the similar call to set a school as the primary school.

Therefore this PR adds a breaking change.