### PR TITLE
Updates untilNow parameter on postAddCompany

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 * Add PUT for setting a company as primary company [#72](https://github.com/xing/XNGAPIClient/pull/72)
 * Change deprecated industry field to new industries field [#73](https://github.com/xing/XNGAPIClient/pull/73)
-
+* Updates untilNow parameter on postAddCompany [#74](https://github.com/xing/XNGAPIClient/pull/74)

--- a/Example/ExampleTests/XNGProfileEditingTests.m
+++ b/Example/ExampleTests/XNGProfileEditingTests.m
@@ -290,7 +290,7 @@
                                                 description:@"XING AG"
                                                  discipline:@"IT_AND_SOFTWARE_DEVELOPMENT"
                                                     endDate:nil
-                                                   untilNow:YES
+                                                   untilNow:@(YES)
                                                         url:@"https://xing.com"
                                                     success:nil
                                                     failure:nil];
@@ -318,8 +318,9 @@
         [body removeObjectForKey:@"description"];
         expect([body valueForKey:@"discipline"]).to.equal(@"IT_AND_SOFTWARE_DEVELOPMENT");
         [body removeObjectForKey:@"discipline"];
-        expect([body valueForKey:@"end_date"]).to.beNil();
-        expect([body valueForKey:@"until_now"]).to.equal(@"true");
+        expect([body valueForKey:@"end_date"]).to.equal([NSNull null]);
+        [body removeObjectForKey:@"end_date"];
+        expect([body valueForKey:@"until_now"]).to.equal(@(YES));
         [body removeObjectForKey:@"until_now"];
         expect([body valueForKey:@"url"]).to.equal(@"https://xing.com");
         [body removeObjectForKey:@"url"];

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.h
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.h
@@ -156,7 +156,7 @@ https://dev.xing.com/docs/put/users/me/private_address
                    description:(NSString *)description
                     discipline:(NSString *)discipline
                        endDate:(NSString *)endDate
-                      untilNow:(BOOL)untilNow
+                      untilNow:(NSNumber *)untilNow
                            url:(NSString *)URL
                        success:(void (^)(id JSON))success
                        failure:(void (^)(NSError *error))failure;

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.m
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.m
@@ -275,7 +275,7 @@
                    description:(NSString *)description
                     discipline:(NSString *)discipline
                        endDate:(NSString *)endDate
-                      untilNow:(BOOL)untilNow
+                      untilNow:(NSNumber *)untilNow
                            url:(NSString *)URL
                        success:(void (^)(id JSON))success
                        failure:(void (^)(NSError *error))failure {
@@ -303,10 +303,11 @@
         parameters[@"discipline"] = discipline;
     }
     if (endDate) {
+        parameters[@"until_now"] = @(NO);
         parameters[@"end_date"] = endDate;
-    }
-    if (untilNow) {
-        parameters[@"until_now"] = @"true";
+    } else if (untilNow) {
+        parameters[@"until_now"] = untilNow;
+        parameters[@"end_date"] = [NSNull null];
     }
     if (URL) {
         parameters[@"url"] = URL;


### PR DESCRIPTION
This is related to https://github.com/xing/XNGAPIClient/pull/70. 

This PR fixes the `until_now` requirement for the POST company call. It seems that the value is required if you use the `end_date` parameter.