### PR TITLE
Swift support

### DIFF
--- a/XNGAPIClient.podspec
+++ b/XNGAPIClient.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
     sp.source_files = 'XNGAPIClient/*.{h,m}'
     sp.dependency 'SSKeychain', '~> 1.2.0'
     sp.dependency 'XNGOAuth1Client', '~> 2.0.0'
+    sp.dependency 'AFNetworking', '~> 2.0'
     sp.frameworks = 'Security','SystemConfiguration', 'UIKit'
   end
 

--- a/XNGAPIClient/XNGAPIClient.h
+++ b/XNGAPIClient/XNGAPIClient.h
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import <XNGOAuth1Client/XNGOAuth1Client.h>
 
 @interface XNGAPIClient : XNGOAuth1Client

--- a/XNGAPIClient/XNGOAuthHandler.h
+++ b/XNGAPIClient/XNGOAuthHandler.h
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "AFNetworking.h"
+#import <AFNetworking/AFNetworking.h>
 
 @interface XNGOAuthHandler : NSObject
 @property (nonatomic, strong, readonly) NSString *accessToken;


### PR DESCRIPTION
This PR contains small changes to enable Swift support on XNGAPIClient.

* Fixes wrong/missing import directives: https://github.com/xing/XNGAPIClient/commit/8622b572af2e66031c7fc404cadf2b811b0c2aab https://github.com/xing/XNGAPIClient/commit/1c17b698fdb26878cadecc30112e8eb101300ea1
* Adds `AFNetworking` as a dependency. For some reason, without this Xcode is not able to build the project using `use_frameworks!` on the Podfile. I'll double check this with the CocoaPods team though, I feel I'm missing something obvious here, because this dependency should be resolved by CocoaPods.