### PR TITLE
Keychain bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 * Change deprecated industry field to new industries field [#73](https://github.com/xing/XNGAPIClient/pull/73)
 * Updates untilNow parameter on postAddCompany [#74](https://github.com/xing/XNGAPIClient/pull/74)
 * Add GET for sent contact requests [#82](https://github.com/xing/XNGAPIClient/pull/82)
+* Keychain bug fixes [#86](https://github.com/xing/XNGAPIClient/pull/86)

--- a/XNGAPIClient/XNGAPIClient.m
+++ b/XNGAPIClient/XNGAPIClient.m
@@ -103,7 +103,9 @@ static XNGAPIClient *_sharedClient = nil;
 #pragma mark - handling login / logout
 
 - (BOOL)isLoggedin {
-    return [self.oAuthHandler hasAccessToken];
+    return [self.oAuthHandler hasAccessToken] &&
+        [self.oAuthHandler hasTokenSecret] &&
+        [self.oAuthHandler hasUserID];
 }
 
 - (void)logout {

--- a/XNGAPIClient/XNGOAuthHandler.h
+++ b/XNGAPIClient/XNGOAuthHandler.h
@@ -41,5 +41,9 @@
 
 - (BOOL)hasAccessToken;
 
+- (BOOL)hasTokenSecret;
+
+- (BOOL)hasUserID;
+
 
 @end

--- a/XNGAPIClient/XNGOAuthHandler.m
+++ b/XNGAPIClient/XNGOAuthHandler.m
@@ -62,15 +62,15 @@ static NSString *kAccessTokenName = @"AccessToken";//Keychain username
 }
 
 - (BOOL)hasAccessToken {
-    return (self.accessToken != nil) && (self.accessToken.length > 0);
+    return self.accessToken.length > 0;
 }
 
 - (BOOL)hasTokenSecret {
-    return (self.tokenSecret != nil) && (self.tokenSecret.length > 0);
+    return self.tokenSecret.length > 0;
 }
 
 - (BOOL)hasUserID {
-    return (self.userID != nil) && (self.userID.length > 0);
+    return self.userID.length > 0;
 }
 
 - (NSString *)accessToken {

--- a/XNGAPIClient/XNGOAuthHandler.m
+++ b/XNGAPIClient/XNGOAuthHandler.m
@@ -151,10 +151,12 @@ static NSString *kAccessTokenName = @"AccessToken";//Keychain username
     NSAssert( !error, @"KeychainTokenSecretWriteError: %@",error);
     _tokenSecret = accessTokenSecret;
 
-    if (error && failure) {
+    if (error) {
         NSAssert(NO,@"Could not save into keychain");
 
-        failure(error);
+        if (failure) {
+            failure(error);
+        }
         return;
     }
 

--- a/XNGAPIClient/XNGOAuthHandler.m
+++ b/XNGAPIClient/XNGOAuthHandler.m
@@ -65,6 +65,14 @@ static NSString *kAccessTokenName = @"AccessToken";//Keychain username
     return (self.accessToken != nil) && (self.accessToken.length > 0);
 }
 
+- (BOOL)hasTokenSecret {
+    return (self.tokenSecret != nil) && (self.tokenSecret.length > 0);
+}
+
+- (BOOL)hasUserID {
+    return (self.userID != nil) && (self.userID.length > 0);
+}
+
 - (NSString *)accessToken {
 	if (_accessToken == nil) {
 		NSError *error;

--- a/XNGAPIClient/XNGOAuthHandler.m
+++ b/XNGAPIClient/XNGOAuthHandler.m
@@ -151,7 +151,7 @@ static NSString *kAccessTokenName = @"AccessToken";//Keychain username
     NSAssert( !error, @"KeychainTokenSecretWriteError: %@",error);
     _tokenSecret = accessTokenSecret;
 
-    if (error) {
+    if (error && failure) {
         NSAssert(NO,@"Could not save into keychain");
 
         failure(error);


### PR DESCRIPTION
This PR contains small fixes related to some keychain issues we discover recently: 

* It checks if the failure block is set before executing it. https://github.com/xing/XNGAPIClient/commit/1a41d932918cfde9ad0c06ce6de54093ba33de89
* For some reason, if some keychain items are not stored or retrieved correctly the authentication flow can break. So we make [this method](https://github.com/xing/XNGAPIClient/commit/0f9aa201ffed1a1340e1abb2517c7dcc44bb62ec) more exhaustive to avoid scenarios where one of those values is missing due keychain errors.