### PR TITLE
Add call to cancel profile picture upload

### DIFF
--- a/Example/ExampleTests/XNGProfileEditingTests.m
+++ b/Example/ExampleTests/XNGProfileEditingTests.m
@@ -76,6 +76,18 @@
     }];
 }
 
+- (void)testCancelUserProfilePictureUpload {
+    [self.testHelper executeCall:^{
+        [[XNGAPIClient sharedClient] cancelPutUpdateUsersProfilePicture];
+    } withExpectations:^(NSURLRequest *request, NSMutableDictionary *query, NSMutableDictionary *body) {
+        expect(request.URL.host).to.equal(@"api.xing.com");
+        expect(request.URL.path).to.equal(@"/v1/users/me/photo");
+        expect(request.HTTPMethod).to.equal(@"PUT");
+        expect([query allKeys]).to.haveCountOf(0);
+        expect(body).toNot.beNil();
+    }];
+}
+
 - (void)testDeleteUsersProfilePicture {
     [self.testHelper executeCall:^{
         [[XNGAPIClient sharedClient] deleteUsersProfilePictureWithSuccess:nil

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.h
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.h
@@ -46,6 +46,8 @@
                                       success:(void (^)(id JSON))success
                                       failure:(void (^)(NSError *error))failure;
 
+- (void)cancelPutUpdateUsersProfilePicture;
+
 /**
  Get profile picture upload progress
  https://dev.xing.com/docs/get/users/me/photo/progress

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.m
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.m
@@ -70,11 +70,19 @@
             @"content": [image xng_base64]
     };
 
-    NSString *path = @"/v1/users/me/photo";
-    [self putJSONPath:path
+    [self putJSONPath:[self pathForProfilePictureUpload]
        JSONParameters:parameters
               success:success
               failure:failure];
+}
+
+- (void)cancelPutUpdateUsersProfilePicture {
+    [self cancelAllHTTPOperationsWithMethod:@"PUT"
+                                       path:[self pathForProfilePictureUpload]];
+}
+
+- (NSString *)pathForProfilePictureUpload {
+    return @"/v1/users/me/photo";
 }
 
 - (void)getUsersProfilePictureProgressWithSuccess:(void (^)(id JSON))success


### PR DESCRIPTION
This PR adds a call to be able to cancel the profile picture upload, as it can take some time on slower networks.