### PR TITLE
Add method to track progress of profile picture photo upload

### DIFF
--- a/Example/ExampleTests/XNGProfileEditingTests.m
+++ b/Example/ExampleTests/XNGProfileEditingTests.m
@@ -59,6 +59,7 @@
     __block UIImage *image = [UIImage imageNamed:@"testimage.jpg"];
     [self.testHelper executeCall:^{
         [[XNGAPIClient sharedClient] putUpdateUsersProfilePictureWithImage:image
+                                                            uploadProgress:nil
                                                                    success:nil
                                                                    failure:nil];
     } withExpectations:^(NSURLRequest *request, NSMutableDictionary *query, NSMutableDictionary *body) {

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.h
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.h
@@ -43,9 +43,6 @@
  https://dev.xing.com/docs/put/users/me/photo
 */
 - (void)putUpdateUsersProfilePictureWithImage:(UIImage *)image
-                                      success:(void (^)(id JSON))success
-                                      failure:(void (^)(NSError *error))failure;
-- (void)putUpdateUsersProfilePictureWithImage:(UIImage *)image
                                uploadProgress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))uploadProgress
                                       success:(void (^)(id JSON))success
                                       failure:(void (^)(NSError *error))failure;

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.h
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.h
@@ -45,6 +45,10 @@
 - (void)putUpdateUsersProfilePictureWithImage:(UIImage *)image
                                       success:(void (^)(id JSON))success
                                       failure:(void (^)(NSError *error))failure;
+- (void)putUpdateUsersProfilePictureWithImage:(UIImage *)image
+                               uploadProgress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))uploadProgress
+                                      success:(void (^)(id JSON))success
+                                      failure:(void (^)(NSError *error))failure;
 
 /**
  Get profile picture upload progress

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.m
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.m
@@ -57,15 +57,6 @@
 }
 
 - (void)putUpdateUsersProfilePictureWithImage:(UIImage *)image
-                                      success:(void (^)(id JSON))success
-                                      failure:(void (^)(NSError *error))failure {
-    [self putUpdateUsersProfilePictureWithImage:image
-                                 uploadProgress:nil
-                                        success:success
-                                        failure:failure];
-}
-
-- (void)putUpdateUsersProfilePictureWithImage:(UIImage *)image
                                uploadProgress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))uploadProgress
                                       success:(void (^)(id JSON))success
                                       failure:(void (^)(NSError *error))failure {

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.m
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.m
@@ -59,20 +59,31 @@
 - (void)putUpdateUsersProfilePictureWithImage:(UIImage *)image
                                       success:(void (^)(id JSON))success
                                       failure:(void (^)(NSError *error))failure {
+    [self putUpdateUsersProfilePictureWithImage:image
+                                 uploadProgress:nil
+                                        success:success
+                                        failure:failure];
+}
+
+- (void)putUpdateUsersProfilePictureWithImage:(UIImage *)image
+                               uploadProgress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))uploadProgress
+                                      success:(void (^)(id JSON))success
+                                      failure:(void (^)(NSError *error))failure {
     if (!image) {
         return;
     }
 
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
     parameters[@"photo"] = @{
-            @"file_name": [image xng_uuidImageName],
-            @"mime_type": @"image/jpeg",
-            @"content": [image xng_base64]
-    };
+                             @"file_name": [image xng_uuidImageName],
+                             @"mime_type": @"image/jpeg",
+                             @"content": [image xng_base64]
+                             };
 
     NSString *path = @"/v1/users/me/photo";
     [self putJSONPath:path
        JSONParameters:parameters
+       uploadProgress:uploadProgress
               success:success
               failure:failure];
 }

--- a/XNGAPIClient/XNGAPIClient.h
+++ b/XNGAPIClient/XNGAPIClient.h
@@ -114,13 +114,22 @@ extern NSString * const XNGAPIClientDeprecationWarningNotification;
                success:(void (^)(id JSON))success
                failure:(void (^)(NSError *error))failure;
 
-#pragma mark - block-based PUT with JSON parameters
+#pragma mark - block-based PUT and POST with JSON parameters
 
 /**
  use this method to make a JSON encoded PUT call to the public XING API.
 */
 - (void)putJSONPath:(NSString *)path
      JSONParameters:(NSDictionary *)parameters
+            success:(void (^)(id JSON))success
+            failure:(void (^)(NSError *error))failure;
+
+/**
+ use this method to make a JSON encoded PUT call to the public XING API and track its progress
+ */
+- (void)putJSONPath:(NSString *)path
+     JSONParameters:(NSDictionary *)parameters
+     uploadProgress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))uploadProgress
             success:(void (^)(id JSON))success
             failure:(void (^)(NSError *error))failure;
 

--- a/XNGAPIClient/XNGAPIClient.m
+++ b/XNGAPIClient/XNGAPIClient.m
@@ -344,10 +344,18 @@ static NSString * const XNGAPIClientOAuthAccessTokenPath = @"v1/access_token";
                  failure:failure];
 }
 
-#pragma mark - block-based PUT with JSON parameters
+#pragma mark - block-based PUT and POST with JSON parameters
 
 - (void)putJSONPath:(NSString *)path
      JSONParameters:(NSDictionary *)parameters
+            success:(void (^)(id JSON))success
+            failure:(void (^)(NSError *error))failure {
+    [self putJSONPath:path JSONParameters:parameters uploadProgress:nil success:success failure:failure];
+}
+
+- (void)putJSONPath:(NSString *)path
+     JSONParameters:(NSDictionary *)parameters
+     uploadProgress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))uploadProgress
             success:(void (^)(id JSON))success
             failure:(void (^)(NSError *error))failure {
     self.requestSerializer = [AFJSONRequestSerializer serializer];
@@ -358,6 +366,7 @@ static NSString * const XNGAPIClientOAuthAccessTokenPath = @"v1/access_token";
     AFHTTPRequestOperation *operation = [self xng_HTTPRequestOperationWithRequest:request
                                                                           success:success
                                                                           failure:failure];
+    [operation setUploadProgressBlock:uploadProgress];
     [self.operationQueue addOperation:operation];
     self.requestSerializer = [AFHTTPRequestSerializer serializer];
 }


### PR DESCRIPTION
This PR adds a method to be able to track the upload progress when uploading a new profile photo. Some considerations:

- This new method uses the new `-putJSONPath:JSONParameters:uploadProgress:success:failure:`, added to be able to track the progress of a PUT operation.
 - Probably it would be better to return the resulting operation and do it there, but that would require a major refactor of our XNGAPIClient.
- I haven't added any specific test for this new `uploadProgress` parameter because`OHHTTPStub` doesn't allow us to test progress. 
 - I have also checked `Nocilla` but it has the same problem, although the API is nicer.
 - I also checked the tests included with `AFNetworking` but could't find any way to test the `uploadProgress` block (https://github.com/AFNetworking/AFNetworking/tree/master/Tests/Tests)