### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you have any questions please open an issue.
 [![Coverage Status](http://img.shields.io/coveralls/xing/XNGAPIClient/master.svg?style=flat)](https://coveralls.io/r/xing/XNGAPIClient)
 [![Dependency Status](https://www.versioneye.com/objective-c/xngapiclient/badge.svg?style=flat)](https://www.versioneye.com/objective-c/xngapiclient)
 [![Reference Status](https://www.versioneye.com/objective-c/xngapiclient/reference_badge.svg?style=flat)](https://www.versioneye.com/objective-c/xngapiclient/references)
-[![Cocoapods Version](http://img.shields.io/cocoapods/v/XNGAPIClient.svg?style=flat)](https://github.com/xing/XNGAPIClient/blob/master/XNGAPIClient.podspec)
+[![CocoaPods Version](http://img.shields.io/cocoapods/v/XNGAPIClient.svg?style=flat)](https://github.com/xing/XNGAPIClient/blob/master/XNGAPIClient.podspec)
 [![](http://img.shields.io/cocoapods/l/XNGAPIClient.svg?style=flat)](https://github.com/xing/XNGAPIClient/blob/master/LICENSE)
 [![CocoaPods Platform](http://img.shields.io/cocoapods/p/XNGAPIClient.svg?style=flat)]()
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
