### PR TITLE
Add GET call for list of industries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Version
 
+* Add GET call for list of industries []()
 * Added top_haves parameter to update user data call [#101](https://github.com/xing/XNGAPIClient/pull/101)
 * Changes `with_contacts`/`withContacts:` in events calls with `with_participants`/`participantsLimit:` [#103](https://github.com/xing/XNGAPIClient/pull/103)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next Version
 
-* Add GET call for list of industries []()
+* Add GET call for list of industries [#104](https://github.com/xing/XNGAPIClient/pull/104)
 * Added top_haves parameter to update user data call [#101](https://github.com/xing/XNGAPIClient/pull/101)
 * Changes `with_contacts`/`withContacts:` in events calls with `with_participants`/`participantsLimit:` [#103](https://github.com/xing/XNGAPIClient/pull/103)
 

--- a/Example/ExampleTests/XNGProfileEditingTests.m
+++ b/Example/ExampleTests/XNGProfileEditingTests.m
@@ -2,6 +2,7 @@
 #import "XNGTestHelper.h"
 #import <XNGAPIClient/UIImage+Base64Encoding.h>
 #import <XNGAPIClient/XNGAPI.h>
+#import <XNGAPIClient/XNGAPIClient+Misc.h>
 
 @interface XNGProfileEditingTests : XCTestCase
 
@@ -571,6 +572,26 @@
         
         expect([query allKeys]).to.haveCountOf(0);
         expect([body valueForKey:@"content"]).to.equal(@"Awesome legal information");
+    }];
+}
+
+- (void)testIndustryList {
+    [self.testHelper executeCall: ^{
+        [[XNGAPIClient sharedClient] getIndustriesForLanguage:@"en"
+                                                      success:nil
+                                                      failure:nil];
+    } withExpectations:^(NSURLRequest *request, NSMutableDictionary *query, NSMutableDictionary *body) {
+        expect(request.URL.host).to.equal(@"api.xing.com");
+        expect(request.URL.path).to.equal(@"/v1/misc/industries");
+        expect(request.HTTPMethod).to.equal(@"GET");
+        
+        [self.testHelper removeOAuthParametersInQueryDict:query];
+        
+        expect([query valueForKey:@"languages"]).to.equal(@"en");
+        [query removeObjectForKey:@"languages"];
+        
+        expect([query allKeys]).to.haveCountOf(0);
+        expect([body allKeys]).to.haveCountOf(0);
     }];
 }
 

--- a/XNGAPIClient/XNGAPIClient+Misc.h
+++ b/XNGAPIClient/XNGAPIClient+Misc.h
@@ -1,0 +1,7 @@
+#import "XNGAPIClient.h"
+
+@interface XNGAPIClient (Misc)
+- (void)getIndustriesForLanguage:(NSString *)language
+                         success:(void (^)(id JSON))success
+                         failure:(void (^)(NSError *error))failure;
+@end

--- a/XNGAPIClient/XNGAPIClient+Misc.m
+++ b/XNGAPIClient/XNGAPIClient+Misc.m
@@ -1,0 +1,16 @@
+#import "XNGAPIClient+Misc.h"
+
+@implementation XNGAPIClient (Misc)
+
+- (void)getIndustriesForLanguage:(NSString *)language
+                         success:(void (^)(id JSON))success
+                         failure:(void (^)(NSError *error))failure {
+    NSMutableDictionary *parameters;
+    if (language.length > 0) {
+        parameters = @{@"languages" : language};
+    }
+    NSString *path = @"v1/misc/industries";
+    [self getJSONPath:path parameters:parameters success:success failure:failure];
+}
+
+@end


### PR DESCRIPTION
Use this call to get a list of industries known to XING.
If language is left empty all supported languages are provided.
See https://dev.xing.com/docs/get/misc/industries for more information.