### PR TITLE
Add GET and DELETE for instant messenger accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Version
 
+* Added call to update and delete an instant messenger account on your profile. [#106](https://github.com/xing/XNGAPIClient/pull/106)
 * Added top_haves parameter to update user data call [#101](https://github.com/xing/XNGAPIClient/pull/101)
 * Changes `with_contacts`/`withContacts:` in events calls with `with_participants`/`participantsLimit:` [#103](https://github.com/xing/XNGAPIClient/pull/103)
 

--- a/Example/ExampleTests/XNGProfileEditingTests.m
+++ b/Example/ExampleTests/XNGProfileEditingTests.m
@@ -574,4 +574,37 @@
     }];
 }
 
+- (void)testUpdateInstantMessengerAccount {
+    [self.testHelper executeCall:^{
+        [[XNGAPIClient sharedClient] putUpdateInstantMessengerAccountWithAccount:@"skype"
+                                                                            name:@"1122334455"
+                                                                         success:nil
+                                                                         failure:nil];
+    } withExpectations:^(NSURLRequest *request, NSMutableDictionary *query, NSMutableDictionary *body) {
+        expect(request.URL.host).to.equal(@"api.xing.com");
+        expect(request.URL.path).to.equal(@"/v1/users/me/instant_messaging_accounts/skype");
+        expect(request.HTTPMethod).to.equal(@"PUT");
+        
+        expect([query allKeys]).to.haveCountOf(0);
+        expect([body valueForKey:@"name"]).to.equal(@"1122334455");
+        [body removeObjectForKey:@"name"];
+        expect([body allKeys]).to.haveCountOf(0);
+    }];
+}
+
+- (void)testDeleteInstantMessengerAccount {
+    [self.testHelper executeCall:^{
+        [[XNGAPIClient sharedClient] deleteInstantMessengerAccount:@"skype"
+                                                           success:nil
+                                                           failure:nil];
+    } withExpectations:^(NSURLRequest *request, NSMutableDictionary *query, NSMutableDictionary *body) {
+        expect(request.URL.host).to.equal(@"api.xing.com");
+        expect(request.URL.path).to.equal(@"/v1/users/me/instant_messaging_accounts/skype");
+        expect(request.HTTPMethod).to.equal(@"DELETE");
+        
+        expect([query allKeys]).to.haveCountOf(0);
+        expect([body allKeys]).to.haveCountOf(0);
+    }];
+}
+
 @end

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.h
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.h
@@ -285,4 +285,14 @@ https://dev.xing.com/docs/put/users/me/private_address
                           success:(void (^)(id JSON))success
                           failure:(void (^)(NSError *error))failure;
 
+/**
+ Update the users instant messenger account
+ 
+ https://dev.xing.com/docs/put/users/me/instant_messaging_accounts/:account
+ */
+- (void)putUpdateInstantMessengerAccountWithAccount:(NSString *)account
+                                               name:(NSString *)name
+                                            success:(void (^)(id JSON))success
+                                            failure:(void (^)(NSError *error))failure;
+
 @end

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.h
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.h
@@ -295,4 +295,13 @@ https://dev.xing.com/docs/put/users/me/private_address
                                             success:(void (^)(id JSON))success
                                             failure:(void (^)(NSError *error))failure;
 
+/**
+ Delete the users instant messenger account
+ 
+ https://dev.xing.com/docs/delete/users/me/instant_messaging_accounts/:account
+ */
+- (void)deleteInstantMessengerAccount:(NSString *)account
+                              success:(void (^)(id JSON))success
+                              failure:(void (^)(NSError *error))failure;
+
 @end

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.m
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.m
@@ -550,14 +550,14 @@
     }
     
     NSString *path = [NSString stringWithFormat:@"v1/users/me/instant_messaging_accounts/%@", account];
-    NSDictionary *parameters = @{@"name" : name};
+    NSDictionary *parameters = @{@"name": name};
     [self putJSONPath:path JSONParameters:parameters success:success failure:failure];
 }
 
 - (void)deleteInstantMessengerAccount:(NSString *)account
                               success:(void (^)(id JSON))success
                               failure:(void (^)(NSError *error))failure {
-    if (account.length == 0) {
+    if (!account) {
         return;
     }
 

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.m
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.m
@@ -540,4 +540,18 @@
     [self putJSONPath:path JSONParameters:parameters success:success failure:failure];
 }
 
+- (void)putUpdateInstantMessengerAccountWithAccount:(NSString *)account
+                                               name:(NSString *)name
+                                            success:(void (^)(id JSON))success
+                                            failure:(void (^)(NSError *error))failure {
+  
+    if (!account || !name) {
+        return;
+    }
+    
+    NSString *path = [NSString stringWithFormat:@"v1/users/me/instant_messaging_accounts/%@", account];
+    NSDictionary *parameters = @{@"name" : name};
+    [self putJSONPath:path JSONParameters:parameters success:success failure:failure];
+}
+
 @end

--- a/XNGAPIClient/XNGAPIClient+ProfileEditing.m
+++ b/XNGAPIClient/XNGAPIClient+ProfileEditing.m
@@ -554,4 +554,15 @@
     [self putJSONPath:path JSONParameters:parameters success:success failure:failure];
 }
 
+- (void)deleteInstantMessengerAccount:(NSString *)account
+                              success:(void (^)(id JSON))success
+                              failure:(void (^)(NSError *error))failure {
+    if (account.length == 0) {
+        return;
+    }
+
+    NSString *path = [NSString stringWithFormat:@"v1/users/me/instant_messaging_accounts/%@", account];
+    [self deleteJSONPath:path parameters:nil success:success failure:failure];
+}
+
 @end


### PR DESCRIPTION
Use this call to update and delete an instant messenger account on your profile.
See https://dev.xing.com/docs/put/users/me/instant_messaging_accounts/:account and https://dev.xing.com/docs/delete/users/me/instant_messaging_accounts/:account for more information.